### PR TITLE
Fix feature test

### DIFF
--- a/frontend/Brocfile.js
+++ b/frontend/Brocfile.js
@@ -4,7 +4,7 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 var app = new EmberApp({
   'ember-cli-jquery-ui': {
-    'theme': 'ui-darkness'
+    'theme': 'smoothness'
   }
 });
 

--- a/frontend/Brocfile.js
+++ b/frontend/Brocfile.js
@@ -2,7 +2,11 @@
 
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
-var app = new EmberApp();
+var app = new EmberApp({
+  'ember-cli-jquery-ui': {
+    'theme': 'ui-darkness'
+  }
+});
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/spec/features/widgets_page_spec.rb
+++ b/spec/features/widgets_page_spec.rb
@@ -2,13 +2,7 @@ require 'rails_helper'
 
 feature "Widgets page", type: :feature, js: true do
   scenario "User visits widget page" do
-    begin
       visit "/widgets"
-    rescue
-      binding.pry
-      puts "wrong line"
-    end
-      binding.pry
     expect(page).to have_text("Ember")
   end
 end


### PR DESCRIPTION
Previously, capybara-based feature specs were timing out, unable to find front-end assets. Adding them as config options in the Ember Brocfile fixes this problem.
